### PR TITLE
Fix generation overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spms_ring"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Todd Stellanova <tstellanova@users.noreply.github.com>"]
 description= "Single publisher, multiple subscriber ring buffer for pubsub"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Previously when the counter used for `write_idx` overflowed, `read_next` would not function properly.  This should now be fixed. 